### PR TITLE
feat(otelfiber): add metrics to otelfiber

### DIFF
--- a/otelfiber/config.go
+++ b/otelfiber/config.go
@@ -2,6 +2,7 @@ package otelfiber
 
 import (
 	"github.com/gofiber/fiber/v2"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -9,6 +10,7 @@ import (
 // config is used to configure the Fiber middleware.
 type config struct {
 	TracerProvider    oteltrace.TracerProvider
+	MeterProvider     otelmetric.MeterProvider
 	Propagators       propagation.TextMapPropagator
 	SpanNameFormatter func(*fiber.Ctx) string
 }
@@ -38,6 +40,14 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.TracerProvider = provider
+	})
+}
+
+// WithMeterProvider specifies a meter provider to use for reporting.
+// If none is specified, the global provider is used.
+func WithMeterProvider(provider otelmetric.MeterProvider) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.MeterProvider = provider
 	})
 }
 

--- a/otelfiber/fiber.go
+++ b/otelfiber/fiber.go
@@ -5,20 +5,30 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/utils"
 	otelcontrib "go.opentelemetry.io/contrib"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 const (
-	tracerKey          = "gofiber-contrib-tracer-fiber"
-	tracerName         = "github.com/gofiber/contrib/otelfiber"
-	defaultServiceName = "fiber-server"
+	tracerKey           = "gofiber-contrib-tracer-fiber"
+	instrumentationName = "github.com/gofiber/contrib/otelfiber"
+	defaultServiceName  = "fiber-server"
+
+	metricNameHttpServerDuration       = "http.server.duration"
+	metricNameHttpServerRequestSize    = "http.server.request.size"
+	metricNameHttpServerResponseSize   = "http.server.response.size"
+	metricNameHttpServerActiveRequests = "http.server.active_requests"
 )
 
 // Middleware returns fiber handler which will trace incoming requests.
@@ -34,13 +44,35 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 		cfg.TracerProvider = otel.GetTracerProvider()
 	}
 	tracer := cfg.TracerProvider.Tracer(
-		tracerName,
+		instrumentationName,
 		oteltrace.WithInstrumentationVersion(otelcontrib.SemVersion()),
 	)
+	if cfg.MeterProvider == nil {
+		cfg.MeterProvider = global.MeterProvider()
+	}
+	meter := cfg.MeterProvider.Meter(
+		instrumentationName,
+		metric.WithInstrumentationVersion(otelcontrib.SemVersion()),
+	)
+	httpServerDuration, err := meter.SyncFloat64().Histogram(metricNameHttpServerDuration, instrument.WithUnit(unit.Milliseconds), instrument.WithDescription("measures the duration inbound HTTP requests"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	httpServerRequestSize, err := meter.SyncInt64().Histogram(metricNameHttpServerRequestSize, instrument.WithUnit(unit.Bytes), instrument.WithDescription("measures the size of HTTP request messages"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	httpServerResponseSize, err := meter.SyncInt64().Histogram(metricNameHttpServerResponseSize, instrument.WithUnit(unit.Bytes), instrument.WithDescription("measures the size of HTTP response messages"))
+	if err != nil {
+		otel.Handle(err)
+	}
+	httpServerActiveRequests, err := meter.SyncInt64().UpDownCounter(metricNameHttpServerActiveRequests, instrument.WithUnit(unit.Dimensionless), instrument.WithDescription("measures the number of concurrent HTTP requests that are currently in-flight"))
+	if err != nil {
+		otel.Handle(err)
+	}
 	if cfg.Propagators == nil {
 		cfg.Propagators = otel.GetTextMapPropagator()
 	}
-
 	if cfg.SpanNameFormatter == nil {
 		cfg.SpanNameFormatter = defaultSpanNameFormatter
 	}
@@ -49,11 +81,16 @@ func Middleware(service string, opts ...Option) fiber.Handler {
 		c.Locals(tracerKey, tracer)
 		savedCtx, cancel := context.WithCancel(c.UserContext())
 
+		start := time.Now()
+		httpServerActiveRequests.Add(savedCtx, 1)
 		defer func() {
+			httpServerDuration.Record(savedCtx, float64(time.Since(start).Microseconds())/1000)
+			httpServerRequestSize.Record(savedCtx, int64(len(c.Request().Body())))
+			httpServerResponseSize.Record(savedCtx, int64(len(c.Response().Body())))
+			httpServerActiveRequests.Add(savedCtx, -1)
 			c.SetUserContext(savedCtx)
 			cancel()
 		}()
-
 		reqHeader := make(http.Header)
 		c.Request().Header.VisitAll(func(k, v []byte) {
 			reqHeader.Add(string(k), string(v))

--- a/otelfiber/go.mod
+++ b/otelfiber/go.mod
@@ -8,6 +8,8 @@ require (
 	go.opentelemetry.io/contrib v1.11.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.11.0
 	go.opentelemetry.io/otel v1.11.0
+	go.opentelemetry.io/otel/metric v0.32.3
 	go.opentelemetry.io/otel/oteltest v1.0.0-RC3
+	go.opentelemetry.io/otel/sdk/metric v0.32.3
 	go.opentelemetry.io/otel/trace v1.11.0
 )

--- a/otelfiber/go.sum
+++ b/otelfiber/go.sum
@@ -47,8 +47,14 @@ go.opentelemetry.io/contrib/propagators/b3 v1.11.0/go.mod h1:mD7gBpRoRgGxheDunJ5
 go.opentelemetry.io/otel v1.0.0-RC3/go.mod h1:Ka5j3ua8tZs4Rkq4Ex3hwgBgOchyPVq5S6P2lz//nKQ=
 go.opentelemetry.io/otel v1.11.0 h1:kfToEGMDq6TrVrJ9Vht84Y8y9enykSZzDDZglV0kIEk=
 go.opentelemetry.io/otel v1.11.0/go.mod h1:H2KtuEphyMvlhZ+F7tg9GRhAOe60moNx61Ex+WmiKkk=
+go.opentelemetry.io/otel/metric v0.32.3 h1:dMpnJYk2KULXr0j8ph6N7+IcuiIQXlPXD4kix9t7L9c=
+go.opentelemetry.io/otel/metric v0.32.3/go.mod h1:pgiGmKohxHyTPHGOff+vrtIH39/R9fiO/WoenUQ3kcc=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC3 h1:MjaeegZTaX0Bv9uB9CrdVjOFM/8slRjReoWoV9xDCpY=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC3/go.mod h1:xpzajI9JBRr7gX63nO6kAmImmYIAtuQblZ36Z+LfCjE=
+go.opentelemetry.io/otel/sdk v1.11.0 h1:ZnKIL9V9Ztaq+ME43IUi/eo22mNsb6a7tGfzaOWB5fo=
+go.opentelemetry.io/otel/sdk v1.11.0/go.mod h1:REusa8RsyKaq0OlyangWXaw97t2VogoO4SSEeKkSTAk=
+go.opentelemetry.io/otel/sdk/metric v0.32.3 h1:lY46wXBbo8IuPDlh1fpVPVy/bCT4wwo3RBYve6UaHOA=
+go.opentelemetry.io/otel/sdk/metric v0.32.3/go.mod h1:nqJPheSpNDSGXhg22BQRgTQedRalfei6tZkmqTavDSk=
 go.opentelemetry.io/otel/trace v1.0.0-RC3/go.mod h1:VUt2TUYd8S2/ZRX09ZDFZQwn2RqfMB5MzO17jBojGxo=
 go.opentelemetry.io/otel/trace v1.11.0 h1:20U/Vj42SX+mASlXLmSGBg6jpI1jQtv682lZtTAOVFI=
 go.opentelemetry.io/otel/trace v1.11.0/go.mod h1:nyYjis9jy0gytE9LXGU+/m1sHTKbRY0fX0hulNNDP1U=
@@ -59,8 +65,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
This patch adds metrics to otelfiber and follows conventions defined by [Semantic Conventions for
HTTP Metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#semantic-conventions-for-http-metrics).
The metric instruments are added:

- http.server.duration
- http.server.request.size
- http.server.response.size
- http.server.active_requests

The Metrics package in the OpenTelmetry-Go is still in progress. However, I believe that this PR is
a good starting point for otelfiber's metrics.

Resolves #50
